### PR TITLE
Page 431 Create Français.json

### DIFF
--- a/431/Français.json
+++ b/431/Français.json
@@ -1,0 +1,86 @@
+[
+  {
+    "top": 47,
+    "left": 248,
+    "height": 118,
+    "width": 239,
+    "text": "Je sais que ça doit être dur de s'habituer à tout ça. Mais toute la ville t'aidera à t'adapter!"
+  },
+  {
+    "top": 183,
+    "left": 321,
+    "height": 49,
+    "width": 81,
+    "text": "Bien sûr."
+  },
+  {
+    "top": 68,
+    "left": 770,
+    "height": 82,
+    "width": 94,
+    "text": "Dis donc, en vitesse..."
+  },
+  {
+    "top": 154,
+    "left": 836,
+    "height": 81,
+    "width": 132,
+    "text": "Est-ce que Cabot est passé?"
+  },
+  {
+    "top": 540,
+    "left": 280,
+    "height": 68,
+    "width": 161,
+    "text": "Les visites n'étaient pas autorisées jusqu'à maintenant."
+  },
+  {
+    "top": 814,
+    "left": 76,
+    "height": 103,
+    "width": 169,
+    "text": "Bien sûr, mais Cabot ne suit pas les règles, n'est-ce pas?"
+  },
+  {
+    "top": 518,
+    "left": 724,
+    "height": 120,
+    "width": 234,
+    "text": "Ce n'est pas grave s'il est passé. Il n'aura pas d'ennuis. On essaie juste de savoir où il est allé."
+  },
+  {
+    "top": 847,
+    "left": 588,
+    "height": 72,
+    "width": 121,
+    "text": "Eh bien, pas ici."
+  },
+  {
+    "top": 1002,
+    "left": 239,
+    "height": 67,
+    "width": 148,
+    "text": "Il est parti et s'est enfui&nbsp;? <i>Encore</i>&nbsp;?"
+  },
+  {
+    "top": 1114,
+    "left": 277,
+    "height": 62,
+    "width": 114,
+    "text": "Réglé comme une horloge."
+  },
+  {
+    "top": 1216,
+    "left": 205,
+    "height": 121,
+    "width": 178,
+    "text": "Je sais qu'il va probablement bien –&nbsp;comme toujours&nbsp;– mais je suis tellement stressée&nbsp;!"
+  },
+  {
+    "top": 989,
+    "left": 730,
+    "height": 115,
+    "width": 218,
+    "text": "Je ne peux pas m'occuper d'un petit fugueur en plus de tout ce qui se passe avec Jentzen."
+  }
+]


### PR DESCRIPTION
Just noticed something, not *really* problematic, but rather odd.
Though HTML tags and entities seems to work, the `&nbsp;` does not seem to function normally, it behaves like a regular space (you can see that when resizing the bubble with the hyphens in panel 5).
That's a very minor thing and we can always play with the size so the readers will never notice, so there's absolutely no emergency nor immediate necessity to dig into this issue, but as I suspect the whole past transcripts will end up being processed somehow into JSON through an automated process, this might be worth a note somewhere, just not to be surprised when the time comes...