### PR TITLE
Page 443 Create Français.json

### DIFF
--- a/443/Français.json
+++ b/443/Français.json
@@ -1,0 +1,72 @@
+[
+  {
+    "top": 71,
+    "left": 245,
+    "height": 67,
+    "width": 92,
+    "text": "Ça va, vous deux&nbsp;?"
+  },
+  {
+    "top": 226,
+    "left": 185,
+    "height": 42,
+    "width": 101,
+    "text": "Oui, maman."
+  },
+  {
+    "top": 298,
+    "left": 229,
+    "height": 58,
+    "width": 99,
+    "text": "Oui, Mme Carver"
+  },
+  {
+    "top": 63,
+    "left": 424,
+    "height": 79,
+    "width": 171,
+    "text": "Je suis vraiment désolée, Parsley, mais le soleil s'est couché..."
+  },
+  {
+    "top": 380,
+    "left": 426,
+    "height": 102,
+    "width": 178,
+    "text": "Oh, oui, bien sûr&nbsp;! Tes mères veulent probablement que tu rentres à la maison pour dîner, hein&nbsp;?"
+  },
+  {
+    "top": 502,
+    "left": 492,
+    "height": 105,
+    "width": 150,
+    "text": "Pas de problème, Mar-Mar. Merci de nous avoir aidés à chercher aujourd'hui."
+  },
+  {
+    "top": 717,
+    "left": 37,
+    "height": 117,
+    "width": 202,
+    "text": "Il ne mourra _pas_ de maladie, d'accord&nbsp;? Je _sais_ que tu t'inquiètes. Arrête."
+  },
+  {
+    "top": 722,
+    "left": 437,
+    "height": 110,
+    "width": 198,
+    "text": "Quoi, moi&nbsp;? Je ne m'inquiète pas&nbsp;! Pourquoi m'inquiéterais-je&nbsp;? C'est juste Cabot, après tout..."
+  },
+  {
+    "top": 886,
+    "left": 499,
+    "height": 90,
+    "width": 100,
+    "text": "_Je suis sérieuse._ À demain."
+  },
+  {
+    "top": 1067,
+    "left": 121,
+    "height": 114,
+    "width": 144,
+    "text": "Ouais, à bientôt&nbsp;! Dis bonjour à tes mamans de ma part&nbsp;!"
+  }
+]


### PR DESCRIPTION
⚠ Weird behavior in the transcript builder: the path for the picture is generated as "/your_content/comics/443/undefined"
That's probably nothing (some database that's not up-to-date?) and I could circumvent the issue using the actual image name.
As I doubt you use different versions of the image, I think the coordinates should be OK.

Pages above 443 can't be found yet by the builder, perhaps there's no English.json for them yet and the system doesn't like it?